### PR TITLE
Net frame extents - wrong tabbed handling

### DIFF
--- a/release-notes/changes/5-set-_NET_FRAME_EXTENTS
+++ b/release-notes/changes/5-set-_NET_FRAME_EXTENTS
@@ -1,0 +1,1 @@
+Set _NET_FRAME_EXTENTS according to the actual decoration size

--- a/src/x.c
+++ b/src/x.c
@@ -1126,6 +1126,24 @@ void x_push_node(Con *con) {
 
     set_shape_state(con, need_reshape);
 
+    /* Set _NET_FRAME_EXTENTS according to the actual decoration size. */
+    if (con != NULL && con->window != NULL) {
+        Rect bsr = con_border_style_rect(con);
+        Rect r = {
+            bsr.x,                  /* left */
+            0 - bsr.width - bsr.x,  /* right */
+            bsr.y,                  /* top */
+            0 - bsr.height - bsr.y  /* bottom */
+        };
+        xcb_change_property(
+            conn,
+            XCB_PROP_MODE_REPLACE,
+            con->window->id,
+            A__NET_FRAME_EXTENTS,
+            XCB_ATOM_CARDINAL, 32, 4,
+            &r);
+    }
+
     /* Map if map state changed, also ensure that the child window
      * is changed if we are mapped and there is a new, unmapped child window.
      * Unmaps are handled in x_push_node_unmaps(). */

--- a/src/x.c
+++ b/src/x.c
@@ -1129,6 +1129,23 @@ void x_push_node(Con *con) {
     /* Set _NET_FRAME_EXTENTS according to the actual decoration size. */
     if (con != NULL && con->window != NULL) {
         Rect bsr = con_border_style_rect(con);
+
+        /* Attempt to include stacked/tabbed titles. */
+        Con *parent = con->parent;
+        if (parent != NULL && (parent->layout == L_STACKED || parent->layout == L_TABBED)) {
+            uint32_t max_y = 0, max_height = 0;
+            TAILQ_FOREACH (current, &(parent->nodes_head), nodes) {
+                Rect *dr = &(current->deco_rect);
+                if (dr->y >= max_y && dr->height >= max_height) {
+                    max_y = dr->y;
+                    max_height = dr->height;
+                }
+            }
+            uint32_t total_deco_height = max_y + max_height;
+            bsr.y += total_deco_height;
+            bsr.height -= total_deco_height;
+        }
+
         Rect r = {
             bsr.x,                  /* left */
             0 - bsr.width - bsr.x,  /* right */


### PR DESCRIPTION
Pulls in changes from a fork that fix some bugs with corner rounding with smart borders as well as potentially gets closer to having rounded corners work with tabbed layouts. 